### PR TITLE
Test for opcache_reset

### DIFF
--- a/_add-ons/webhooks/hooks.webhooks.php
+++ b/_add-ons/webhooks/hooks.webhooks.php
@@ -43,8 +43,10 @@ class Hooks_webhooks extends Hooks
 
 	private function clearOpCache()
 	{
-		opcache_reset();
-		$this->log->info('OpCache has been cleared.');
+		if (function_exists('opcache_reset')) {
+			opcache_reset();
+			$this->log->info('OpCache has been cleared.');
+		}
 	}
 
 	private function clearHtmlCache()

--- a/_add-ons/webhooks/hooks.webhooks.php
+++ b/_add-ons/webhooks/hooks.webhooks.php
@@ -46,6 +46,8 @@ class Hooks_webhooks extends Hooks
 		if (function_exists('opcache_reset')) {
 			opcache_reset();
 			$this->log->info('OpCache has been cleared.');
+		} else {
+			$this->log->info('OpCache could not be cleared. OpCache requires PHP 5.5.');
 		}
 	}
 


### PR DESCRIPTION
Since clearing the opcache is the default, it could make sense to make attempting to clear it a bit safer in PHP < 5.5.
